### PR TITLE
Fix rate handling bug in currency bot

### DIFF
--- a/currency_rate_bot/src/currency-bot/currency-bot.service.ts
+++ b/currency_rate_bot/src/currency-bot/currency-bot.service.ts
@@ -119,10 +119,11 @@ export class CurrencyBotService implements OnModuleInit {
       const kafkaMessage: { symbol: string; rate: string }[] = [];
 
       for (const pair of CURRENCY_PAIRS) {
-        const rate = Number(ratesMap.get(pair));
-        if (rate !== undefined) {
+        const rateValue = ratesMap.get(pair);
+        if (rateValue !== undefined) {
+          const rate = Number(rateValue);
           await this.redisClient.set(pair, rate.toString());
-          kafkaMessage.push({ symbol: pair, rate: rate.toString() })
+          kafkaMessage.push({ symbol: pair, rate: rate.toString() });
         }
       }
 
@@ -139,6 +140,6 @@ export class CurrencyBotService implements OnModuleInit {
 
   @MessagePattern('user.notify')
   handleNotification(@Payload() message: any) {
-    this.bot.telegram.sendMessage(message.chatId, message)
+    this.bot.telegram.sendMessage(message.chatId, message.text ?? String(message));
   }
 }


### PR DESCRIPTION
## Summary
- prevent NaN rates from being stored by checking availability in the map
- send notification text properly in Telegram messages

## Testing
- `npm run build`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_683ff830ca78832ca2564815f1ab8f2a